### PR TITLE
option to delete exported keys

### DIFF
--- a/bin/riak-bucket-exporter.js
+++ b/bin/riak-bucket-exporter.js
@@ -121,10 +121,12 @@ function processKey(key, cb) {
     first=false;
     
     if (deleteKeys) {
-        db.remove(bucket, key);
+        db.remove(bucket, key, function (err) {
+            cb();
+        });
+    } else {
+        return cb();
     }
-    
-    return cb();
   });
 }
 

--- a/bin/riak-bucket-exporter.js
+++ b/bin/riak-bucket-exporter.js
@@ -23,13 +23,12 @@ var count = 0;
 var openWrites = 0;
 var db = require("riak-js").getClient({host: program.host, port: program.port});
 var fs = require('fs');
-var deleteKeys = false;
+var deleteKeys = !program.import && !!program.delete;
 
 if (program.import) {
   importToBucket();
 } else {
   if (program.delete) {
-    deleteKeys = true;
     console.log('WARNING: keys will be deleted as they are exported');
   }
   
@@ -120,13 +119,13 @@ function processKey(key, cb) {
     fs.appendFileSync(program.file, JSON.stringify(out,null,'\t'));
     first=false;
     
-    if (deleteKeys) {
-        db.remove(bucket, key, function (err) {
-            cb();
-        });
-    } else {
-        return cb();
+    if (!deleteKeys) {
+      return cb();
     }
+    
+    db.remove(bucket, key, function (err) {
+      cb();
+    });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
     "async": "^0.9.0",
     "commander": "^2.3.0",
     "riak-js": "^0.10.2"
-  }
+  },
+  "contributors": [{
+    "name": "Craig Thayer",
+    "email": "cthayer@sazze.com"
+  }]
 }


### PR DESCRIPTION
Allow an option to be specified during export (`--delete`) that deletes the exported keys from riak as they are exported (after being appended to the output file)
